### PR TITLE
Swap null comparisons to avoid issues with arrays being passed in

### DIFF
--- a/StorageMigrationServiceHelper.psm1
+++ b/StorageMigrationServiceHelper.psm1
@@ -31,7 +31,7 @@ Function GetSmsLogsFolder($Path, [ref]$SmsLogsFolder)
     do
     {
         $p = $Path + "\$folderNamePrefix"
-        if ($suffix -ne $null)
+        if ($null -ne $suffix)
         {
             $p += "_$suffix"
             $suffix += 1
@@ -69,7 +69,7 @@ Function GetSmsEventLogs($SmsLogsFolder)
         }
         else
         {
-            if ($Credential -eq $null)
+            if ($null -eq $Credential)
             {
                 Get-WinEvent -ComputerName $targetComputerName -logname $key -oldest -ea SilentlyContinue | foreach-object {$_.Message} > "$outFullFile"
             }
@@ -110,7 +110,7 @@ Function GetSmsEventLogs2($SmsLogsFolder)
         }
         else
         {
-            if ($Credential -eq $null)
+            if ($null -eq $Credential)
             {
                 Get-WinEvent -ComputerName $targetComputerName -logname $key -oldest -ea SilentlyContinue | foreach-object {#write "$_.TimeCreated $_.Id $_.LevelDisplayName $_.Message"} > "$outFullFile"
                     $id=$_.Id;
@@ -152,7 +152,7 @@ Function GetSystemEventLogs($SmsLogsFolder)
     }
     else
     {
-        if ($Credential -eq $null)
+        if ($null -eq $Credential)
         {
             get-winevent -ComputerName $targetComputerName -logname System -oldest -ea SilentlyContinue | foreach-object {
                 $id=$_.Id;
@@ -183,7 +183,7 @@ Function GetSystemInfo($SmsLogsFolder)
     }
     else
     {
-        if ($Credential -eq $null)
+        if ($null -eq $Credential)
         {
             $remoteFeatures = Get-WindowsFeature -ComputerName $targetComputerName
         }
@@ -237,7 +237,7 @@ Function GetSystemInfo($SmsLogsFolder)
         }
         else
         {
-            if ($Credential -eq $null)
+            if ($null -eq $Credential)
             {
                 $smsStates = Get-SmsState -OrchestratorComputerName $targetComputerName
             }
@@ -262,7 +262,7 @@ write "After ###################"
             }
             else
             {
-                if ($Credential -eq $null)
+                if ($null -eq $Credential)
                 {
                     $inventorySummary = Get-SmsState -OrchestratorComputerName $targetComputerName -Name $job -InventorySummary
                 }
@@ -286,7 +286,7 @@ write "After ###################"
                 }
                 else
                 {
-                    if ($Credential -eq $null)
+                    if ($null -eq $Credential)
                     {
                         $detail = Get-SmsState -OrchestratorComputerName $targetComputerName -Name $job -ComputerName $device -InventoryConfigDetail
                     }
@@ -307,7 +307,7 @@ write "After ###################"
                 }
                 else
                 {
-                    if ($Credential -eq $null)
+                    if ($null -eq $Credential)
                     {
                         $detail = Get-SmsState -OrchestratorComputerName $targetComputerName -Name $job -ComputerName $device -InventorySMBDetail
                     }
@@ -331,7 +331,7 @@ write "After ###################"
                 }
                 else
                 {
-                    if ($Credential -eq $null)
+                    if ($null -eq $Credential)
                     {
                         $transferSummary = Get-SmsState -OrchestratorComputerName $targetComputerName -Name $job -TransferSummary
                     }
@@ -355,7 +355,7 @@ write "After ###################"
                     }
                     else
                     {
-                        if ($Credential -eq $null)
+                        if ($null -eq $Credential)
                         {
                             $detail = Get-SmsState -OrchestratorComputerName $targetComputerName -Name $job -ComputerName -ComputerName $device $device -TransferSMBDetail
                         }
@@ -377,7 +377,7 @@ write "After ###################"
                 }
                 else
                 {
-                    if ($Credential -eq $null)
+                    if ($null -eq $Credential)
                     {
                         $cutoverSummary = Get-SmsState -OrchestratorComputerName $targetComputerName -Name $job -CutoverSummary
                     }
@@ -403,7 +403,7 @@ Function Get-SmsLogs (
 {
     $error.Clear()
     
-    if ($ComputerName -eq $null -or $ComputerName -eq "")
+    if ($null -eq $ComputerName -or $ComputerName -eq "")
     {
         $computerNameWasProvided = $false
         $targetComputerName = "$env:ComputerName"


### PR DESCRIPTION
PSScriptAnalyzer warns against having the null on the right hand side of a comparison (see https://github.com/PowerShell/PSScriptAnalyzer/issues/477 for more details) and can result in unintended behaviour.